### PR TITLE
파일 삭제 로직 수정

### DIFF
--- a/src/main/java/com/example/employee_system/controller/FileController.java
+++ b/src/main/java/com/example/employee_system/controller/FileController.java
@@ -68,7 +68,7 @@ public class FileController {
    //파일 다운로드
     @GetMapping("/download/{fileId}")
     public ResponseEntity<Resource> downloadFile(@PathVariable("fileId") String fileId) throws IOException {
-        //파일 아이디 long 타입으로 변경하기
+        //파일 아이디 long 타입으로 변경하기ㄹ
         long id = Long.parseLong(fileId);
 
         //경로 확인하기

--- a/src/main/java/com/example/employee_system/service/FileService.java
+++ b/src/main/java/com/example/employee_system/service/FileService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.imageio.IIOException;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -81,8 +82,23 @@ public class FileService {
     //파일 삭제하기
     @Transactional
     public void deleteFile(Long id){
+        // 1. 디스크 파일 데이터 삭제
+        // 1-1. 파일 데이터의 경로 조회
+        FileDto fileDto = getFileById(id);
+        String filePath = fileDto.getSavePath()+"/"+fileDto.getSaveName();
+        System.out.println("파일 삭제 경로 확인 : "+ filePath);
+        deleteFileFromDisk(filePath);
 
+        // 2. db 파일 데이터 삭제
         fileMapper.deleteFileById(id);
+    }
+
+    //파일 삭제 (from Disk) - 물리적 삭제
+    public void deleteFileFromDisk(String filePath){
+        File file = new File(filePath);
+        if(file.exists()){
+            file.delete();
+        }
     }
 
     //파일 수정하기


### PR DESCRIPTION
- 현재는 DB 상에서만 삭제 됨.
- 로컬도 함께 삭제가 필요
    - 문제점 발견 ) 기존에 db데이터 삭제 → 디스크 데이터 삭제 진행하였는데. 그렇게 되면 이미 db에서 데이터가 삭제되며 디스크 데이터를 삭제하기 위한 파일명과 경로 조회가 안되었음
    - 해결방법) 디스크 데이터 삭제 후 db 데이터 삭제 순서로 진행하면 문제 없음